### PR TITLE
Update CI workflows for testing Linux and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,44 @@
-name: "NaiveDate CI"
+name: CI
 
-on: 
+on:
   push:
-    branches: 
+    branches:
       - master
   pull_request:
-    branches: 
-      - '*'
+    branches:
+      - master
 
 jobs:
-  macos-run-tests:
-    name: Unit Tests (macOS, Xcode 13.2)
-    runs-on: macOS-11
+  macos:
+    name: macOS (Xcode ${{ matrix.xcode }})
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode: ["13.4.1", "13.2.1"]
+        include:
+          - xcode: "13.4.1"
+            macos: macOS-12
+          - xcode: "13.2.1"
+            macos: macOS-11
+    runs-on: ${{ matrix.macos }}
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repo
+        uses: actions/checkout@v3
       - name: Run Tests
         run: swift test
+  linux:
+    name: Linux (Swift ${{ matrix.swift }})
+    strategy:
+      fail-fast: false
+      matrix:
+        swift: ["5.5", "5.6"]
+    runs-on: ubuntu-latest
+    container: swift:${{ matrix.swift }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Run Tests
+        run: swift test
+


### PR DESCRIPTION
This change just aligns the ci.yml to run just like the other repos, including Linux coverage